### PR TITLE
redshift: drop table if exists

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,8 @@ script:
   - go get github.com/tools/godep
   - mkdir -p $GOPATH/src/github.com/Clever
   - ln -s `pwd` $GOPATH/src/github.com/Clever/redshifter
+  - export AWS_ACCESS_KEY_ID=x
+  - export AWS_SECRET_ACCESS_KEY=x
   - make test
 notify:
   email:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,6 @@
 image: bradrydzewski/go:1.3
 script:
+  - go get github.com/tools/godep
   - mkdir -p $GOPATH/src/github.com/Clever
   - ln -s `pwd` $GOPATH/src/github.com/Clever/redshifter
   - make test

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: go1.4
+image: bradrydzewski/go:1.3
 script:
   - mkdir -p $GOPATH/src/github.com/Clever
   - ln -s `pwd` $GOPATH/src/github.com/Clever/redshifter

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUBPKG_NAMES := mixpanel postgres redshift
 SUBPKGS = $(addprefix $(PKG)/, $(SUBPKG_NAMES))
 PKGS = $(PKG) $(SUBPKGS)
 
-.PHONY: test golint README
+.PHONY: test golint docs
 
 test: docs $(PKGS)
 
@@ -16,9 +16,6 @@ $(GOPATH)/bin/golint:
 
 $(GOPATH)/bin/godocdown:
 	@go get github.com/robertkrimen/godocdown/godocdown
-
-README.md: $(GOPATH)/bin/godocdown *.go
-	@$(GOPATH)/bin/godocdown -template=.godocdown.template $(PKG) > README.md
 
 $(PKGS): $(GOPATH)/bin/golint docs
 	@go get -d -t $@

--- a/mixpanel/mixpanel_export_test.go
+++ b/mixpanel/mixpanel_export_test.go
@@ -61,5 +61,5 @@ func TestRequest(t *testing.T) {
 	expurl := "https://data.mixpanel.com/api/2.0/method/?api_key=apikey&events=%5B%22event1%22%2C%22event2%22%5D&expire=10000600&format=json&param1=value1&param2=value2&sig=825125f9640ce6bee7b6c25fd33eacb3"
 	url, err := m.Request("method", params)
 	assert.NoError(t, err)
-	assert.Equal(t, expurl, url)
+	assert.Equal(t, expurl, string(url))
 }

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -127,7 +127,7 @@ func (r *Redshift) RefreshTable(name, prefix, file, awsRegion string, ts postgre
 	if err := r.CopyGzipCsvDataFromS3(tmptable, file, awsRegion, delim); err != nil {
 		return err
 	}
-	_, err := r.logAndExec(fmt.Sprintf("DROP TABLE %s; ALTER TABLE %s RENAME TO %s;", name, tmptable, name), false)
+	_, err := r.logAndExec(fmt.Sprintf("DROP TABLE IF EXISTS %s; ALTER TABLE %s RENAME TO %s;", name, tmptable, name), false)
 	return err
 }
 

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -29,7 +29,7 @@ func TestCopyJSONDataFromS3(t *testing.T) {
 	mockrs := Redshift{&cmds, "accesskey", "secretkey"}
 	err := mockrs.CopyJSONDataFromS3(table, file, jsonpathsFile, awsRegion)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{exp}, cmds)
+	assert.Equal(t, mockSQLDB{exp}, cmds)
 }
 
 func TestCopyGzipCsvDataFromS3(t *testing.T) {
@@ -42,7 +42,7 @@ func TestCopyGzipCsvDataFromS3(t *testing.T) {
 	mockrs := Redshift{&cmds, "accesskey", "secretkey"}
 	err := mockrs.CopyGzipCsvDataFromS3(table, file, awsRegion, delimiter)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{exp}, cmds)
+	assert.Equal(t, mockSQLDB{exp}, cmds)
 }
 
 func TestCreateTable(t *testing.T) {
@@ -56,7 +56,7 @@ func TestCreateTable(t *testing.T) {
 	mockrs := Redshift{&cmds, "accesskey", "secretkey"}
 	err := mockrs.createTable("tablename", ts)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{exp}, cmds)
+	assert.Equal(t, mockSQLDB{exp}, cmds)
 }
 
 func TestRefreshTable(t *testing.T) {
@@ -70,7 +70,7 @@ func TestRefreshTable(t *testing.T) {
 		prefix+name, file, awsRegion, delim)
 	copycmd += " ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE COMPUPDATE ON"
 	copycmd += " CREDENTIALS 'aws_access_key_id=accesskey;aws_secret_access_key=secretkey'"
-	expcmds := []string{
+	expcmds := mockSQLDB{
 		"DROP TABLE IF EXISTS test_prefix_tablename",
 		"CREATE TABLE test_prefix_tablename (field1 type1  NOT NULL, field2 type2 SORTKEY PRIMARY KEY, field3 type3 DEFAULT defaultval3 )",
 		copycmd,

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -74,7 +74,7 @@ func TestRefreshTable(t *testing.T) {
 		"DROP TABLE IF EXISTS test_prefix_tablename",
 		"CREATE TABLE test_prefix_tablename (field1 type1  NOT NULL, field2 type2 SORTKEY PRIMARY KEY, field3 type3 DEFAULT defaultval3 )",
 		copycmd,
-		"DROP TABLE tablename; ALTER TABLE test_prefix_tablename RENAME TO tablename;",
+		"DROP TABLE IF EXISTS tablename; ALTER TABLE test_prefix_tablename RENAME TO tablename;",
 	}
 	cmds := mockSQLDB([]string{})
 	mockrs := Redshift{&cmds, "accesskey", "secretkey"}


### PR DESCRIPTION
If the destination table hasn't yet been created in Redshift, you
don't need to drop it. This failure to drop causes and error
and causes the github.com/clever/postgres-to-redshift to fail
on initial import (data gets imported but only to 'temp' table
name)