### PR TITLE
Fix the ALTER TABLE command when refreshing redshift tables

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -123,8 +123,8 @@ func (r *Redshift) RefreshTable(schema, name, prefix, file, awsRegion string, ts
 	if err := r.CopyGzipCsvDataFromS3(schema, tmptable, file, awsRegion, delim); err != nil {
 		return err
 	}
-	_, err := r.logAndExec(fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s"; ALTER TABLE "%s"."%s" RENAME TO "%s"."%s";`,
-		schema, name, schema, tmptable, schema, name), false)
+	_, err := r.logAndExec(fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s"; ALTER TABLE "%s"."%s" RENAME TO "%s";`,
+		schema, name, schema, tmptable, name), false)
 	return err
 }
 

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -74,7 +74,7 @@ func TestRefreshTable(t *testing.T) {
 		"DROP TABLE IF EXISTS \"testschema\".\"test_prefix_tablename\"",
 		"CREATE TABLE \"testschema\".\"test_prefix_tablename\" (field1 type1  NOT NULL, field2 type2 SORTKEY PRIMARY KEY, field3 type3 DEFAULT defaultval3 )",
 		copycmd,
-		"DROP TABLE IF EXISTS \"testschema\".\"tablename\"; ALTER TABLE \"testschema\".\"test_prefix_tablename\" RENAME TO \"testschema\".\"tablename\";",
+		"DROP TABLE IF EXISTS \"testschema\".\"tablename\"; ALTER TABLE \"testschema\".\"test_prefix_tablename\" RENAME TO \"tablename\";",
 	}
 	cmds := mockSQLDB([]string{})
 	mockrs := Redshift{&cmds, "accesskey", "secretkey"}


### PR DESCRIPTION
Rename does not allow setting the schema in the new name.

Tested: Ran the actual command.