### PR TITLE
Grant select and references priviliges to public after refresh

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -123,8 +123,11 @@ func (r *Redshift) RefreshTable(schema, name, prefix, file, awsRegion string, ts
 	if err := r.CopyGzipCsvDataFromS3(schema, tmptable, file, awsRegion, delim); err != nil {
 		return err
 	}
-	_, err := r.logAndExec(fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s"; ALTER TABLE "%s"."%s" RENAME TO "%s";`,
-		schema, name, schema, tmptable, name), false)
+	if _, err := r.logAndExec(fmt.Sprintf(`DROP TABLE IF EXISTS "%s"."%s"; ALTER TABLE "%s"."%s" RENAME TO "%s";`,
+		schema, name, schema, tmptable, name), false); err != nil {
+		return err
+	}
+	_, err := r.logAndExec(fmt.Sprintf(`GRANT SELECT, REFERENCES ON "%s"."%s" TO PUBLIC`, schema, name), false)
 	return err
 }
 

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -71,10 +71,11 @@ func TestRefreshTable(t *testing.T) {
 	copycmd += " ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE COMPUPDATE ON"
 	copycmd += " CREDENTIALS 'aws_access_key_id=accesskey;aws_secret_access_key=secretkey'"
 	expcmds := mockSQLDB{
-		"DROP TABLE IF EXISTS \"testschema\".\"test_prefix_tablename\"",
-		"CREATE TABLE \"testschema\".\"test_prefix_tablename\" (field1 type1  NOT NULL, field2 type2 SORTKEY PRIMARY KEY, field3 type3 DEFAULT defaultval3 )",
+		`DROP TABLE IF EXISTS "testschema"."test_prefix_tablename"`,
+		`CREATE TABLE "testschema"."test_prefix_tablename" (field1 type1  NOT NULL, field2 type2 SORTKEY PRIMARY KEY, field3 type3 DEFAULT defaultval3 )`,
 		copycmd,
-		"DROP TABLE IF EXISTS \"testschema\".\"tablename\"; ALTER TABLE \"testschema\".\"test_prefix_tablename\" RENAME TO \"tablename\";",
+		`DROP TABLE IF EXISTS "testschema"."tablename"; ALTER TABLE "testschema"."test_prefix_tablename" RENAME TO "tablename";`,
+		`GRANT SELECT, REFERENCES ON "testschema"."tablename" TO PUBLIC`,
 	}
 	cmds := mockSQLDB([]string{})
 	mockrs := Redshift{&cmds, "accesskey", "secretkey"}


### PR DESCRIPTION
Without the grant query, users no longer have access once a table gets refreshed

Tested: Unit tests and ran the query locally.