### PR TITLE
redshift: allow Vacuum/Analyze on one table

### DIFF
--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -152,3 +152,8 @@ func (r *Redshift) VacuumAnalyze() error {
 	_, err := r.logAndExec("VACUUM FULL; ANALYZE", false)
 	return err
 }
+
+func (r *Redshift) VacuumAnalyzeTable(table string) error {
+	_, err := r.logAndExec(fmt.Sprintf(`VACUUM FULL "%s"; ANALYZE "%s"`, table, table), false)
+	return err
+}


### PR DESCRIPTION
Allow vacuuming/analyze per table. Running on full database can be very slow, and isn't relevant when you're just modifying one table