### PR TITLE
Modify redshifter before including s3-to-redshift work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 PKG := github.com/Clever/redshifter
 SUBPKG_NAMES := mixpanel postgres redshift
 SUBPKGS = $(addprefix $(PKG)/, $(SUBPKG_NAMES))
-PKGS = $(PKG) $(SUBPKGS)
+PKGS = $(PKG)/cmd/ $(SUBPKGS)
 
 .PHONY: test golint docs
 

--- a/cmd/mixpanel_to_redshift.go
+++ b/cmd/mixpanel_to_redshift.go
@@ -67,9 +67,14 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := r.CopyJSONDataFromS3(*schema, *table, exportFile, *jsonpathsFile); err != nil {
+		// do use s3 creds, don't use GZIP
+		// I am not confident this currently works - you may have to set timeformat to 'epochsecs'
+		copySQL := r.GetJSONCopySQL(*schema, *table, exportFile, *jsonpathsFile, true, false)
+		err = r.SafeExec([]string{copySQL})
+		if err != nil {
 			log.Fatal(err)
 		}
+
 		if err := r.VacuumAnalyze(); err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/mixpanel_to_redshift.go
+++ b/cmd/mixpanel_to_redshift.go
@@ -69,9 +69,15 @@ func main() {
 		}
 		// do use s3 creds, don't use GZIP
 		// I am not confident this currently works - you may have to set timeformat to 'epochsecs'
-		copySQL := r.GetJSONCopySQL(*schema, *table, exportFile, *jsonpathsFile, true, false)
-		err = r.SafeExec([]string{copySQL})
+		tx, err := r.Begin()
 		if err != nil {
+			log.Fatal(err)
+		}
+		if err := r.RunJSONCopy(tx, *schema, *table, exportFile, *jsonpathsFile, true, false); err != nil {
+			tx.Rollback()
+			log.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
 			log.Fatal(err)
 		}
 

--- a/cmd/mixpanel_to_redshift.go
+++ b/cmd/mixpanel_to_redshift.go
@@ -24,14 +24,14 @@ var (
 		"Date in YYYY-MM-DD format. Defaults to yesterday.")
 	mixpanelExportDir = flag.String("exportdir", "", "Directory to store the exported mixpanel data.")
 	host              = flag.String("host", "", "Address of the redshift host")
-	port              = flag.Int("port", 0, "Address of the redshift host")
+	port              = flag.String("port", "5439", "Port of the redshift host")
 	db                = flag.String("database", "", "Redshift database to connect to")
 	user              = flag.String("user", "", "Redshift user to connect as")
 	schema            = flag.String("schema", "public", "Schema with the redshift table.")
 	table             = flag.String("table", "", "Name of the redshift table.")
 	pwd               = flag.String("password", "", "Password for the redshift user")
-	timeout           = flag.Duration("connecttimeout", 10*time.Second,
-		"Timeout while connecting to Redshift. Defaults to 10 seconds.")
+	redshiftTimeout   = flag.Int("connecttimeout", 10,
+		"Timeout in seconds while connecting to Redshift. Defaults to 10 seconds.")
 	exportFromMixpanel = flag.Bool("export", true, "Whether to export from mixpanel.")
 	copyToRedshift     = flag.Bool("copy", true, "Whether to copy to redshift.")
 )
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	if *copyToRedshift {
-		r, err := redshift.NewRedshift(*host, *port, *db, *user, *pwd, int(*redshiftTimeout.Seconds()))
+		r, err := redshift.NewRedshift(*host, *port, *db, *user, *pwd, *redshiftTimeout)
 		defer r.Close()
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/mixpanel_to_redshift.go
+++ b/cmd/mixpanel_to_redshift.go
@@ -67,21 +67,17 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		// do use s3 creds, don't use GZIP
-		// I am not confident this currently works - you may have to set timeformat to 'epochsecs'
 		tx, err := r.Begin()
 		if err != nil {
 			log.Fatal(err)
 		}
+		// do use s3 creds, don't use GZIP
+		// I am not confident this currently works - you may have to set timeformat to 'epochsecs'
 		if err := r.RunJSONCopy(tx, *schema, *table, exportFile, *jsonpathsFile, true, false); err != nil {
 			tx.Rollback()
 			log.Fatal(err)
 		}
 		if err := tx.Commit(); err != nil {
-			log.Fatal(err)
-		}
-
-		if err := r.VacuumAnalyze(); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmd/mixpanel_to_redshift.go
+++ b/cmd/mixpanel_to_redshift.go
@@ -28,7 +28,7 @@ var (
 	user              = flag.String("user", "", "Redshift user to connect as")
 	schema            = flag.String("schema", "public", "Schema with the redshift table.")
 	table             = flag.String("table", "", "Name of the redshift table.")
-	pwd               = flag.String("password", "", "Password for the redshift user")
+	password          = flag.String("password", "", "Password for the redshift user")
 	redshiftTimeout   = flag.Int("connecttimeout", 10,
 		"Timeout in seconds while connecting to Redshift. Defaults to 10 seconds.")
 	exportFromMixpanel = flag.Bool("export", true, "Whether to export from mixpanel.")
@@ -62,7 +62,7 @@ func main() {
 			AccessID:  env.MustGet("AWS_ACCESS_KEY_ID"),
 			SecretKey: env.MustGet("AWS_SECRET_ACCESS_KEY"),
 		}
-		r, err := redshift.NewRedshift(*host, *port, *db, *user, *pwd, *redshiftTimeout, s3Info)
+		r, err := redshift.NewRedshift(*host, *port, *db, *user, *password, *redshiftTimeout, s3Info)
 		defer r.Close()
 		if err != nil {
 			log.Fatal(err)

--- a/mixpanel_to_redshift.go
+++ b/mixpanel_to_redshift.go
@@ -22,9 +22,16 @@ var (
 	mixpanelExportDate = flag.String("exportdate",
 		time.Now().AddDate(0, 0, -1).Format("2006-01-02"),
 		"Date in YYYY-MM-DD format. Defaults to yesterday.")
-	mixpanelExportDir  = flag.String("exportdir", "", "Directory to store the exported mixpanel data.")
-	redshiftSchema     = flag.String("redshiftschema", "public", "Schema with the redshift table.")
-	redshiftTable      = flag.String("redshifttable", "", "Name of the redshift table.")
+	mixpanelExportDir = flag.String("exportdir", "", "Directory to store the exported mixpanel data.")
+	host              = flag.String("host", "", "Address of the redshift host")
+	port              = flag.Int("port", 0, "Address of the redshift host")
+	db                = flag.String("database", "", "Redshift database to connect to")
+	user              = flag.String("user", "", "Redshift user to connect as")
+	schema            = flag.String("schema", "public", "Schema with the redshift table.")
+	table             = flag.String("table", "", "Name of the redshift table.")
+	pwd               = flag.String("password", "", "Password for the redshift user")
+	timeout           = flag.Duration("connecttimeout", 10*time.Second,
+		"Timeout while connecting to Redshift. Defaults to 10 seconds.")
 	exportFromMixpanel = flag.Bool("export", true, "Whether to export from mixpanel.")
 	copyToRedshift     = flag.Bool("copy", true, "Whether to copy to redshift.")
 )
@@ -51,12 +58,12 @@ func main() {
 	}
 
 	if *copyToRedshift {
-		r, err := redshift.NewRedshift()
+		r, err := redshift.NewRedshift(*host, *port, *db, *user, *pwd, int(*redshiftTimeout.Seconds()))
 		defer r.Close()
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := r.CopyJSONDataFromS3(*redshiftSchema, *redshiftTable, exportFile, *jsonpathsFile, awsRegion); err != nil {
+		if err := r.CopyJSONDataFromS3(*schema, *table, exportFile, *jsonpathsFile, awsRegion); err != nil {
 			log.Fatal(err)
 		}
 		if err := r.VacuumAnalyze(); err != nil {

--- a/redshift/README.md
+++ b/redshift/README.md
@@ -18,15 +18,16 @@ redshift database.
 #### func  NewRedshift
 
 ```go
-func NewRedshift(host, port, db, user, pwd string, timeout int) (*Redshift, error)
+func NewRedshift(host, port, db, user, pwd string, timeout int, s3Info S3Info) (*Redshift, error)
 ```
 NewRedshift returns a pointer to a new redshift object using configuration
-values passed in on instantiation and the AWS env vars we assume exist
+values passed in on instantiation and the AWS env vars we assume exist Don't
+need to pass s3 info unless doing a COPY operation
 
 #### func (*Redshift) CopyGzipCsvDataFromS3
 
 ```go
-func (r *Redshift) CopyGzipCsvDataFromS3(schema, table, file, awsRegion string, ts postgres.TableSchema, delimiter rune) error
+func (r *Redshift) CopyGzipCsvDataFromS3(schema, table, file string, ts postgres.TableSchema, delimiter rune) error
 ```
 CopyGzipCsvDataFromS3 copies gzipped CSV data from an S3 file into a redshift
 table.
@@ -34,7 +35,7 @@ table.
 #### func (*Redshift) CopyJSONDataFromS3
 
 ```go
-func (r *Redshift) CopyJSONDataFromS3(schema, table, file, jsonpathsFile, awsRegion string) error
+func (r *Redshift) CopyJSONDataFromS3(schema, table, file, jsonpathsFile string) error
 ```
 CopyJSONDataFromS3 copies JSON data present in an S3 file into a redshift table.
 
@@ -42,7 +43,7 @@ CopyJSONDataFromS3 copies JSON data present in an S3 file into a redshift table.
 
 ```go
 func (r *Redshift) RefreshTables(
-	tables map[string]postgres.TableSchema, schema, tmpschema, s3prefix, awsRegion string, delim rune) error
+	tables map[string]postgres.TableSchema, schema, tmpschema, s3prefix string, delim rune) error
 ```
 RefreshTables refreshes multiple tables in parallel and returns an error if any
 of the copies fail.
@@ -64,3 +65,15 @@ func (r *Redshift) VacuumAnalyzeTable(schema, table string) error
 VacuumAnalyzeTable performs VACUUM FULL; ANALYZE on a specific table. This is
 useful for recreating the indices after a database has been modified and
 updating the query planner.
+
+#### type S3Info
+
+```go
+type S3Info struct {
+	Region    string
+	AccessID  string
+	SecretKey string
+}
+```
+
+S3Info holds the information necessary to copy data from s3 buckets

--- a/redshift/README.md
+++ b/redshift/README.md
@@ -18,10 +18,10 @@ redshift database.
 #### func  NewRedshift
 
 ```go
-func NewRedshift() (*Redshift, error)
+func NewRedshift(host, port, db, user, pwd string, timeout int) (*Redshift, error)
 ```
 NewRedshift returns a pointer to a new redshift object using configuration
-values set in the flags.
+values passed in on instantiation and the AWS env vars we assume exist
 
 #### func (*Redshift) CopyGzipCsvDataFromS3
 
@@ -53,5 +53,14 @@ of the copies fail.
 func (r *Redshift) VacuumAnalyze() error
 ```
 VacuumAnalyze performs VACUUM FULL; ANALYZE on the redshift database. This is
+useful for recreating the indices after a database has been modified and
+updating the query planner.
+
+#### func (*Redshift) VacuumAnalyzeTable
+
+```go
+func (r *Redshift) VacuumAnalyzeTable(schema, table string) error
+```
+VacuumAnalyzeTable performs VACUUM FULL; ANALYZE on a specific table. This is
 useful for recreating the indices after a database has been modified and
 updating the query planner.

--- a/redshift/README.md
+++ b/redshift/README.md
@@ -18,7 +18,7 @@ redshift database.
 #### func  NewRedshift
 
 ```go
-func NewRedshift(host, port, db, user, pwd string, timeout int, s3Info S3Info) (*Redshift, error)
+func NewRedshift(host, port, db, user, password string, timeout int, s3Info S3Info) (*Redshift, error)
 ```
 NewRedshift returns a pointer to a new redshift object using configuration
 values passed in on instantiation and the AWS env vars we assume exist Don't

--- a/redshift/README.md
+++ b/redshift/README.md
@@ -9,25 +9,25 @@
 
 ```go
 type ColInfo struct {
-	Ordinal    int    `yaml:"ordinal"`
-	Name       string `yaml:"dest"`
-	Type       string `yaml:"type"`
-	DefaultVal string `yaml:"defaultval"`
-	NotNull    bool   `yaml:"notnull"`
-	PrimaryKey bool   `yaml:"primarykey"`
-	DistKey    bool   `yaml:"distkey"`
-	SortOrd    int    `yaml:"sortord"`
+	Ordinal     int    `yaml:"ordinal"`
+	Name        string `yaml:"dest"`
+	Type        string `yaml:"type"`
+	DefaultVal  string `yaml:"defaultval"`
+	NotNull     bool   `yaml:"notnull"`
+	PrimaryKey  bool   `yaml:"primarykey"`
+	DistKey     bool   `yaml:"distkey"`
+	SortOrdinal int    `yaml:"sortord"`
 }
 ```
 
 ColInfo is a struct that contains information about a column in a Redshift
-database. SortKey and DistKey only make sense for Redshift
+database. SortOrdinal and DistKey only make sense for Redshift
 
 #### type Meta
 
 ```go
 type Meta struct {
-	DataDateColumn string `yaml:"data_date_column"`
+	DataDateColumn string `yaml:"datadatecolumn"`
 	Schema         string `yaml:"schema"`
 }
 ```

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -107,7 +107,7 @@ func (r *Redshift) RunJSONCopy(tx *sql.Tx, schema, table, filename, jsonPaths st
 	if gzip {
 		gzipSQL = "GZIP"
 	}
-	copySQL := `COPY "?"."?" FROM '?' WITH ? JSON '?' REGION '?' TIMEFORMAT 'auto' STATUPDATE COMPUPDATE ON %s`
+	copySQL := `COPY "?"."?" FROM '?' WITH ? JSON '?' REGION '?' TIMEFORMAT 'auto' STATUPDATE ON COMPUPDATE ON %s`
 	copyStmt, err := r.Prepare(fmt.Sprintf(copySQL, credSQL))
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func (r *Redshift) RunCSVCopy(tx *sql.Tx, schema, table, file string, ts Table, 
 	}
 
 	copySQL := fmt.Sprintf(`COPY "?"."?" (?) FROM '?' WITH REGION '?' ? CSV DELIMITER '?'`)
-	opts := "IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE STATUPDATE COMPUPDATE ON"
+	opts := "IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE STATUPDATE ON COMPUPDATE ON"
 	fullCopySQL := fmt.Sprintf("%s %s %s", copySQL, opts, credSQL)
 	copyStmt, err := r.Prepare(fullCopySQL)
 	if err != nil {

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -46,7 +46,7 @@ type Table struct {
 // NOTE: this will be useful for the s3-to-redshift worker, but is currently not very useful
 // same with the yaml info
 type Meta struct {
-	DataDateColumn string `yaml:"data_date_column"`
+	DataDateColumn string `yaml:"datadatecolumn"`
 	Schema         string `yaml:"schema"`
 }
 

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -30,6 +30,44 @@ type Redshift struct {
 	s3Info S3Info
 }
 
+// Table is our representation of a Redshift table
+// the main difference is an added metadata section and YAML unmarshalling guidance
+type Table struct {
+	Name    string    `yaml:"dest"`
+	Columns []ColInfo `yaml:"columns"`
+	Meta    Meta      `yaml:"meta"`
+}
+
+// Meta holds information that might be not in Redshift or annoying to access
+// in this case, we want to know the schema a table is part of
+// and the column which corresponds to the timestamp at which the data was gathered
+// NOTE: this will be useful for the s3-to-redshift worker, but is currently not very useful
+// same with the yaml info
+type Meta struct {
+	DataDateColumn string `yaml:"data_date_column"`
+	Schema         string `yaml:"schema"`
+}
+
+// ColInfo is a struct that contains information about a column in a Redshift database.
+// SortKey and DistKey only make sense for Redshift
+type ColInfo struct {
+	Ordinal    int    `yaml:"ordinal"`
+	Name       string `yaml:"dest"`
+	Type       string `yaml:"type"`
+	DefaultVal string `yaml:"defaultval"`
+	NotNull    bool   `yaml:"notnull"`
+	PrimaryKey bool   `yaml:"primarykey"`
+	DistKey    bool   `yaml:"distkey"`
+	SortOrd    int    `yaml:"sortord"`
+}
+
+// Just a helper to make sure the CSV copy works properly
+type SortableColumns []ColInfo
+
+func (c SortableColumns) Len() int           { return len(c) }
+func (c SortableColumns) Less(i, j int) bool { return c[i].Ordinal < c[j].Ordinal }
+func (c SortableColumns) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+
 var (
 )
 
@@ -49,68 +87,76 @@ func NewRedshift(host, port, db, user, password string, timeout int, s3Info S3In
 }
 
 func (r *Redshift) logAndExec(cmd string) (sql.Result, error) {
-	log.Print("Executing Redshift command: ", cmd)
+	log.Print("Executing Redshift command: ", cmd) // TODO: filter out creds, perhaps
 	return r.Exec(cmd)
 }
 
-// CopyJSONDataFromS3 copies JSON data present in an S3 file into a redshift table.
-func (r *Redshift) CopyJSONDataFromS3(schema, table, file, jsonpathsFile string) error {
-	creds := fmt.Sprintf(`CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`, r.s3Info.AccessID, r.s3Info.SecretKey)
-	copyCmd := fmt.Sprintf(
-		`COPY "%s"."%s" FROM '%s' WITH json '%s' region '%s' timeformat 'epochsecs' COMPUPDATE ON %s`,
-		schema, table, file, jsonpathsFile, r.s3Info.Region, creds,
-	)
-	_, err := r.logAndExec(copyCmd)
-	return err
-}
-
-// CopyGzipCsvDataFromS3 copies gzipped CSV data from an S3 file into a redshift table.
-func (r *Redshift) CopyGzipCsvDataFromS3(schema, table, file string, ts postgres.TableSchema, delimiter rune) error {
-	cols := []string{}
-	sort.Sort(ts)
-	for _, ci := range ts {
-		cols = append(cols, ci.Name)
+// GetJSONCopySQL copies JSON data present in an S3 file into a redshift table.
+// if not using jsonPaths, set to "auto"
+func (r *Redshift) GetJSONCopySQL(schema, table, filename, jsonPaths string, creds, gzip bool) string {
+	credSQL := ""
+	if creds {
+		credSQL = fmt.Sprintf(`CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`, r.s3Info.AccessID, r.s3Info.SecretKey)
+	}
+	gzipSQL := ""
+	if gzip {
+		gzipSQL = "GZIP"
 	}
 	copyCmd := fmt.Sprintf(
-		`COPY "%s"."%s" (%s) FROM '%s' WITH REGION '%s' GZIP CSV DELIMITER '%c'`,
-		schema, table, strings.Join(cols, ", "), file, r.s3Info.Region, delimiter)
-	opts := " IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE COMPUPDATE ON"
-	creds := fmt.Sprintf(` CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`, r.s3Info.AccessID, r.s3Info.SecretKey)
-	fullCopyCmd := fmt.Sprintf("%s%s%s", copyCmd, opts, creds)
-	_, err := r.logAndExec(fullCopyCmd)
-	return err
+		`COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' COMPUPDATE ON %s`,
+		schema, table, filename, gzipSQL, jsonPaths, r.s3Info.Region, credSQL)
+	return copyCmd
 }
 
-// Creates a table in tmpschema using the structure of the existing table in schema.
-func (r *Redshift) createTempTable(tmpschema, schema, name string) error {
-	cmd := fmt.Sprintf(`CREATE TABLE "%s"."%s" (LIKE "%s"."%s")`, tmpschema, name, schema, name)
-	_, err := r.logAndExec(cmd)
-	return err
-}
-
-// refreshData atomically clears out a table and loads in the contents of a table in the temp schema
-func (r *Redshift) refreshData(tmpschema, schema, name string) error {
-	cmds := []string{
-		"BEGIN TRANSACTION",
-		fmt.Sprintf(`DELETE FROM "%s"."%s"`, schema, name),
-		fmt.Sprintf(`INSERT INTO "%s"."%s" (SELECT * FROM "%s"."%s")`, schema, name, tmpschema, name),
-		"END TRANSACTION",
+// GetCSVCopySQL copies gzipped CSV data from an S3 file into a redshift table.
+func (r *Redshift) GetCSVCopySQL(schema, table, file string, ts Table, delimiter rune, creds, gzip bool) string {
+	credSQL := ""
+	if creds {
+		credSQL = fmt.Sprintf(`CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`, r.s3Info.AccessID, r.s3Info.SecretKey)
 	}
+	gzipSQL := ""
+	if gzip {
+		gzipSQL = "GZIP"
+	}
+
+	cols := SortableColumns{}
+	cols = append(cols, ts.Columns...)
+	sort.Sort(cols)
+	colStrings := []string{}
+	for _, ci := range cols {
+		colStrings = append(colStrings, ci.Name)
+	}
+	copyCmd := fmt.Sprintf(
+		`COPY "%s"."%s" (%s) FROM '%s' WITH REGION '%s' %s CSV DELIMITER '%c'`,
+		schema, table, strings.Join(colStrings, ", "), file, r.s3Info.Region, gzipSQL, delimiter)
+	opts := "IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE COMPUPDATE ON"
+	fullCopyCmd := fmt.Sprintf("%s %s %s", copyCmd, opts, credSQL)
+	return fullCopyCmd
+}
+
+// SafeExec allows execution of SQL in a transaction block
+// While it seems a little dangerous to export such a powerful function, it is very difficult
+// to control execution control and actually effectively use this library without this ability
+func (r *Redshift) SafeExec(sqlIn []string) error {
+	cmds := append([]string{"BEGIN TRANSACTION"}, sqlIn...)
+	cmds = append(cmds, "END TRANSACTION")
 	_, err := r.logAndExec(strings.Join(cmds, "; "))
 	return err
 }
 
-// RefreshTable refreshes a single table by first copying gzipped CSV data into a temporary table
+// GetTruncateSQL simply returns SQL that deletes all items from a table, given a schema string and a table name
+func (r *Redshift) GetTruncateSQL(schema, table string) string {
+	return fmt.Sprintf(`DELETE FROM "%s"."%s"`, schema, table)
+}
+
+// RefreshTable refreshes a single table by copying gzipped CSV data into a temporary table
 // and later replacing the original table's data with the one from the temporary table in an
 // atomic operation.
-func (r *Redshift) refreshTable(schema, name, tmpschema, file string, ts postgres.TableSchema, delim rune) error {
-	if err := r.createTempTable(tmpschema, schema, name); err != nil {
-		return err
-	}
-	if err := r.CopyGzipCsvDataFromS3(tmpschema, name, file, ts, delim); err != nil {
-		return err
-	}
-	if err := r.refreshData(tmpschema, schema, name); err != nil {
+func (r *Redshift) refreshTable(schema, name, file string, ts Table, delim rune) error {
+	truncateSQL := r.GetTruncateSQL(schema, name)
+	copySQL := r.GetCSVCopySQL(schema, name, file, ts, delim, true, true)
+	err := r.SafeExec([]string{truncateSQL, copySQL})
+	if err != nil {
 		return err
 	}
 	return r.VacuumAnalyzeTable(schema, name)
@@ -119,15 +165,12 @@ func (r *Redshift) refreshTable(schema, name, tmpschema, file string, ts postgre
 // RefreshTables refreshes multiple tables in parallel and returns an error if any of the copies
 // fail.
 func (r *Redshift) RefreshTables(
-	tables map[string]postgres.TableSchema, schema, tmpschema, s3prefix string, delim rune) error {
-	if _, err := r.logAndExec(fmt.Sprintf(`CREATE SCHEMA "%s"`, tmpschema)); err != nil {
-		return err
-	}
+	tables map[string]Table, schema, s3prefix string, delim rune) error {
 	group := new(errgroup.Group)
 	for name, ts := range tables {
 		group.Add(1)
-		go func(name string, ts postgres.TableSchema) {
-			if err := r.refreshTable(schema, name, tmpschema, postgres.S3Filename(s3prefix, name), ts, delim); err != nil {
+		go func(name string, ts Table) {
+			if err := r.refreshTable(schema, name, postgres.S3Filename(s3prefix, name), ts, delim); err != nil {
 				group.Error(err)
 			}
 			group.Done()
@@ -135,9 +178,6 @@ func (r *Redshift) RefreshTables(
 	}
 	errs := new(errgroup.Group)
 	if err := group.Wait(); err != nil {
-		errs.Error(err)
-	}
-	if _, err := r.logAndExec(fmt.Sprintf(`DROP SCHEMA "%s" CASCADE`, tmpschema)); err != nil {
 		errs.Error(err)
 	}
 	// Use errs.Wait() to group the two errors into a single error object.

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -36,11 +36,11 @@ var (
 // NewRedshift returns a pointer to a new redshift object using configuration values passed in
 // on instantiation and the AWS env vars we assume exist
 // Don't need to pass s3 info unless doing a COPY operation
-func NewRedshift(host, port, db, user, pwd string, timeout int, s3Info S3Info) (*Redshift, error) {
+func NewRedshift(host, port, db, user, password string, timeout int, s3Info S3Info) (*Redshift, error) {
 	flag.Parse()
 	source := fmt.Sprintf("host=%s port=%d dbname=%s connect_timeout=%d", host, port, db, timeout)
 	log.Println("Connecting to Redshift Source: ", source)
-	source += fmt.Sprintf(" user=%s password=%s", user, pwd)
+	source += fmt.Sprintf(" user=%s password=%s", user, password)
 	sqldb, err := sql.Open("postgres", source)
 	if err != nil {
 		return nil, err

--- a/redshift/redshift.go
+++ b/redshift/redshift.go
@@ -51,16 +51,16 @@ type Meta struct {
 }
 
 // ColInfo is a struct that contains information about a column in a Redshift database.
-// SortKey and DistKey only make sense for Redshift
+// SortOrdinal and DistKey only make sense for Redshift
 type ColInfo struct {
-	Ordinal    int    `yaml:"ordinal"`
-	Name       string `yaml:"dest"`
-	Type       string `yaml:"type"`
-	DefaultVal string `yaml:"defaultval"`
-	NotNull    bool   `yaml:"notnull"`
-	PrimaryKey bool   `yaml:"primarykey"`
-	DistKey    bool   `yaml:"distkey"`
-	SortOrd    int    `yaml:"sortord"`
+	Ordinal     int    `yaml:"ordinal"`
+	Name        string `yaml:"dest"`
+	Type        string `yaml:"type"`
+	DefaultVal  string `yaml:"defaultval"`
+	NotNull     bool   `yaml:"notnull"`
+	PrimaryKey  bool   `yaml:"primarykey"`
+	DistKey     bool   `yaml:"distkey"`
+	SortOrdinal int    `yaml:"sortord"`
 }
 
 // A helper to make sure the CSV copy works properly

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -15,7 +15,7 @@ func TestGetJSONCopySQL(t *testing.T) {
 		SecretKey: "secretkey",
 	}
 	schema, table, file, jsonpathsFile := "testschema", "tablename", "s3://path", "s3://jsonpathsfile"
-	sql := `COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' STATUPDATE COMPUPDATE ON CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
+	sql := `COPY "%s"."%s" FROM '%s' WITH %s JSON '%s' REGION '%s' TIMEFORMAT 'auto' STATUPDATE ON COMPUPDATE ON CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
 	prepStatement := fmt.Sprintf(sql, "?", "?", "?", "?", "?", "?", "?", "?")
 	execRegex := fmt.Sprintf(sql, ".*", ".*", ".*", ".*", ".*", ".*", ".*", ".*") // slightly awk
 
@@ -59,7 +59,7 @@ func TestCopyGzipCsvDataFromS3(t *testing.T) {
 	}
 
 	sql := `COPY "%s"."%s" (%s) FROM '%s' WITH REGION '%s' %s CSV DELIMITER '%s'`
-	sql += " IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE STATUPDATE COMPUPDATE ON"
+	sql += " IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE STATUPDATE ON COMPUPDATE ON"
 	sql += ` CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
 	prepStatement := fmt.Sprintf(sql, "?", "?", "?", "?", "?", "?", "?", "?", "?")
 	execRegex := fmt.Sprintf(sql, ".*", ".*", ".*", ".*", ".*", ".*", ".*", ".*", ".*") // slightly awk
@@ -101,7 +101,7 @@ func TestRefreshTable(t *testing.T) {
 	schema, name, file, delim := "testschema", "tablename", "s3://path", '|'
 
 	sql := `COPY "%s"."%s" (%s) FROM '%s' WITH REGION '%s' %s CSV DELIMITER '%s'`
-	sql += " IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE STATUPDATE COMPUPDATE ON"
+	sql += " IGNOREHEADER 0 ACCEPTINVCHARS TRUNCATECOLUMNS TRIMBLANKS BLANKSASNULL EMPTYASNULL DATEFORMAT 'auto' ACCEPTANYDATE STATUPDATE ON COMPUPDATE ON"
 	sql += ` CREDENTIALS 'aws_access_key_id=%s;aws_secret_access_key=%s'`
 	prepStatement := fmt.Sprintf(sql, "?", "?", "?", "?", "?", "?", "?", "?", "?")
 	execRegex := fmt.Sprintf(sql, ".*", ".*", ".*", ".*", ".*", ".*", ".*", ".*", ".*") // slightly awk

--- a/redshift/redshift_test.go
+++ b/redshift/redshift_test.go
@@ -116,7 +116,6 @@ func TestRefreshTable(t *testing.T) {
 	mock.ExpectExec(execRegex).WithArgs(schema, name, "foo",
 		file, s3Info.Region, "GZIP", delim, s3Info.AccessID, s3Info.SecretKey).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
-	mock.ExpectExec(`VACUUM FULL "testschema"."tablename"; ANALYZE "testschema"."tablename"`).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// run the refresh table
 	assert.NoError(t, mockrs.refreshTable(schema, name, file, ts, delim))


### PR DESCRIPTION
Closing #16 and #17 in favor of this one.

Big changes, mostly moving to golang sql library transactions instead of our poor-man's transactions :)

The only weird thing here is the `s3Info` struct, don't worry about that one @agclever and @bstein-clever , the PR when I modify for `s3-to-redshift` will have a different way of handling it that will probably make you happy.